### PR TITLE
Core 1.0.3 compatible, bump version to 1.0.1-dev

### DIFF
--- a/assets/template.php
+++ b/assets/template.php
@@ -2,14 +2,20 @@
 /**
  * Template for Link list module
  *
- * $this is an instace of the LinkList object. Ex. use: $this->content to output value.
+ * $this is an instace of the LinkList object.
+ *
+ * Available properties:
+ * $this->heading (string) Module heading.
+ * $this->collection (array) Lists with content.
+ * $this->type (string) List look -> narrow or wide
  *
  * @package Hogan
  */
 
+declare( strict_types = 1 );
 namespace Dekode\Hogan;
 
-if ( ! defined( 'ABSPATH' ) || ! ( $this instanceof LinkList ) || empty( $this->type ) ) {
+if ( ! defined( 'ABSPATH' ) || ! ( $this instanceof LinkList ) ) {
 	return; // Exit if accessed directly.
 }
 

--- a/class-linklist.php
+++ b/class-linklist.php
@@ -5,6 +5,7 @@
  * @package Hogan
  */
 
+declare( strict_types = 1 );
 namespace Dekode\Hogan;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,13 +20,6 @@ if ( ! class_exists( '\\Dekode\\Hogan\\LinkList' ) && class_exists( '\\Dekode\\H
 	 * @extends Modules base class.
 	 */
 	class LinkList extends Module {
-
-		/**
-		 * LinkList heading
-		 *
-		 * @var string $heading
-		 */
-		public $heading;
 
 		/**
 		 * List type
@@ -64,8 +58,10 @@ if ( ! class_exists( '\\Dekode\\Hogan\\LinkList' ) && class_exists( '\\Dekode\\H
 
 		/**
 		 * Field definitions for module.
+		 *
+		 * @return array $fields Fields for this module
 		 */
-		public function get_fields() {
+		public function get_fields() : array {
 
 			$fields = [];
 
@@ -268,25 +264,22 @@ if ( ! class_exists( '\\Dekode\\Hogan\\LinkList' ) && class_exists( '\\Dekode\\H
 		 * Map fields to object variable.
 		 *
 		 * @param array $content The content value.
+		 *
+		 * @return bool Whether validation of the module is successful / filled with content.
 		 */
-		public function load_args_from_layout_content( $content ) {
+		public function load_args_from_layout_content( array $raw_content, int $counter = 0 ) {
 
-			$this->heading = $content['heading'] ?? null;
-			$this->type = $content['list_type'] ?? null;
-			$this->collection = $content['list_flex'] ?? null;
-			$this->boxes = [
-				'content_type' => $content['boxes_content'] ?? null,
-				'content' => 'predefined' === $content['boxes_content'] ? $content['box_predefined_list'] : $content['boxes_list'],
-			];
-
-			parent::load_args_from_layout_content( $content );
+			$this->type = $raw_content['list_type'] ?? null;
+			$this->collection =  $raw_content['list_flex'] ?? '';
+			$this->boxes = null;
+			parent::load_args_from_layout_content( $raw_content, $counter );
 		}
 
 		/**
 		 * Validate module content before template is loaded.
 		 */
-		public function validate_args() {
-			return ! empty( $this->collection ) || ! empty( $this->boxes );
+		public function validate_args() : bool {
+			return ! empty( $this->collection );
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
   "type": "wordpress-plugin",
   "license": "GPL-3.0",
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.0",
     "composer/installers": "~1.2",
-    "dekodeinteraktiv/hogan-core": "@dev"
+    "dekodeinteraktiv/hogan-core": "^1.0"
   },
   "archive": {
     "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "80a06034684908a250b3ec02e66bb5a1",
+    "content-hash": "b8a06c3abc8917bb933e8be98525bf94",
     "packages": [
         {
             "name": "composer/installers",
@@ -125,21 +125,21 @@
         },
         {
             "name": "dekodeinteraktiv/hogan-core",
-            "version": "dev-master",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DekodeInteraktiv/hogan-core.git",
-                "reference": "b04480d2c7fa2c42c9a7caa1c3fc06c2297ae2aa"
+                "reference": "010ce97f21587722e4d8c2c70860a49323647d29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DekodeInteraktiv/hogan-core/zipball/b04480d2c7fa2c42c9a7caa1c3fc06c2297ae2aa",
-                "reference": "b04480d2c7fa2c42c9a7caa1c3fc06c2297ae2aa",
+                "url": "https://api.github.com/repos/DekodeInteraktiv/hogan-core/zipball/010ce97f21587722e4d8c2c70860a49323647d29",
+                "reference": "010ce97f21587722e4d8c2c70860a49323647d29",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "~1.2",
-                "php": ">=5.5"
+                "php": ">=7.0"
             },
             "type": "wordpress-plugin",
             "notification-url": "https://packagist.org/downloads/",
@@ -148,19 +148,17 @@
             ],
             "description": "Modular Flexible Content System for ACF Pro",
             "homepage": "https://github.com/DekodeInteraktiv/hogan-core",
-            "time": "2017-11-16T10:01:02+00:00"
+            "time": "2017-12-06T08:05:41+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "dekodeinteraktiv/hogan-core": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=7.0"
     },
     "platform-dev": []
 }

--- a/hogan-linklist.php
+++ b/hogan-linklist.php
@@ -2,8 +2,9 @@
 /**
  * Plugin Name: Hogan Module: Link list
  * Plugin URI: https://github.com/dekodeinteraktiv/hogan-linklist
+ * GitHub Plugin URI: https://github.com/dekodeinteraktiv/hogan-linklist
  * Description: Link List Module for Hogan
- * Version: 1.0.0-dev
+ * Version: 1.0.1-dev
  * Author: Dekode
  * Author URI: https://dekode.no
  * License: GPL-3.0
@@ -16,6 +17,7 @@
  * @author Dekode
  */
 
+declare( strict_types = 1 );
 namespace Dekode\Hogan\LinkList;
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
1. Add GitHub Plugin URI
2. PHP 7.0 in composer.json
3. Updates for Core 1.0.3
 - updated load_args_from_layout_content()
-  updated get_fields
- removed heading variable
- use strict types
4. Describe variables in template (will be updated more in a later version)