### PR TITLE
1.0.7

### DIFF
--- a/assets/template.php
+++ b/assets/template.php
@@ -21,10 +21,6 @@ if ( ! defined( 'ABSPATH' ) || ! ( $this instanceof LinkList ) ) {
 
 $container_classes = apply_filters( 'hogan/module/linklist/container_classes', [ 'hogan-linklist-container', $this->type ], $this );
 $container_li_classes = apply_filters( 'hogan/module/linklist/container_li_classes', [], $this );
-
-$list_classes = apply_filters( 'hogan/module/linklist/list_classes', [], $this );
-$list_li_classes = apply_filters( 'hogan/module/linklist/list_li_classes', [], $this );
-
 ?>
 
 <?php if ( ! empty( $this->heading ) ) : ?>
@@ -41,6 +37,10 @@ $list_li_classes = apply_filters( 'hogan/module/linklist/list_li_classes', [], $
 		if ( empty( $items ) ) {
 			continue;
 		}
+
+		$list_classes = apply_filters( 'hogan/module/linklist/list_classes', [], $this, $items );
+		$list_li_classes = apply_filters( 'hogan/module/linklist/list_li_classes', [], $this, $items );
+
 		?>
 		<li class="<?php echo esc_attr( implode( ' ', $container_li_classes ) ); ?>">
 			<?php if ( ! empty( $list['list_heading'] ) ) : ?>

--- a/hogan-linklist.php
+++ b/hogan-linklist.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/dekodeinteraktiv/hogan-linklist
  * GitHub Plugin URI: https://github.com/dekodeinteraktiv/hogan-linklist
  * Description: Link List Module for Hogan
- * Version: 1.0.6
+ * Version: 1.0.7
  * Author: Dekode
  * Author URI: https://dekode.no
  * License: GPL-3.0


### PR DESCRIPTION
Flytter filterene `hogan/module/linklist/list_classes` og `hogan/module/linklist/list_li_classes` inn i loopen slik at `$items` (lenker) er tilgjengelig for filteret.

Bruksområde: Hvis utseènde på feks bokser skal være forskjellig avhengig av antall lenker. På Nasjonalbiblioteket er det designet slik.